### PR TITLE
Update card order

### DIFF
--- a/kanban_proj/kanban_app/serializers.py
+++ b/kanban_proj/kanban_app/serializers.py
@@ -24,7 +24,7 @@ class ColumnSerializer(serializers.ModelSerializer):
         read_only_fields = ('id', 'board')
 
     def get_cards(self, instance):
-        cards = instance.cards.all().order_by('-order')
+        cards = instance.cards.all().order_by('order', 'id')
         return CardSerializer(cards, many=True).data
 
 
@@ -37,5 +37,10 @@ class BoardSerializer(serializers.ModelSerializer):
         read_only_fields = ('id', 'owner')
 
     def get_columns(self, instance):
-        columns = instance.columns.all().order_by('-order')
+        columns = instance.columns.all().order_by('id')
         return ColumnSerializer(columns, many=True).data
+
+
+class ReorderColumnCardsSerializer(serializers.Serializer):
+    ordered_dict = serializers.JSONField(required=True)
+

--- a/kanban_proj/kanban_app/urls.py
+++ b/kanban_proj/kanban_app/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
-from .views import BoardList, BoardDetail, ColumnListByBoard, ColumnDetail, CardListByColumn, CardDetail
+from .views import BoardList, BoardDetail, ColumnListByBoard, ColumnDetail, CardListByColumn, CardDetail, \
+    ReorderColumnCards
 
 app_name = 'kanban_app'
 urlpatterns = [
@@ -8,6 +9,7 @@ urlpatterns = [
     path('board/<int:pk>', BoardDetail.as_view(), name='board_detail'),
 
     path('column/board/<int:board_id>', ColumnListByBoard.as_view(), name='column_list_by_board'),
+    path('column/<int:pk>/order', ReorderColumnCards.as_view(), name='order_column_cards'),
     path('column/<int:pk>', ColumnDetail.as_view(), name='column_detail'),
 
     path('card/column/<int:column_id>', CardListByColumn.as_view(), name='card_list_by_column'),

--- a/kanban_proj/kanban_app/views.py
+++ b/kanban_proj/kanban_app/views.py
@@ -1,8 +1,12 @@
-from rest_framework import generics
+from django.db.models import F
+from django.http import Http404
+from rest_framework import generics, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import get_object_or_404
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
-from .serializers import BoardSerializer, ColumnSerializer, CardSerializer
+from .serializers import BoardSerializer, ColumnSerializer, CardSerializer, ReorderColumnCardsSerializer
 from .models import Board, Column, Card
 
 
@@ -57,6 +61,7 @@ class ColumnDetail(generics.RetrieveUpdateDestroyAPIView):
     def perform_update(self, serializer):
         if serializer.validated_data['board'].owner != self.request.user:
             raise PermissionDenied
+        serializer.save()
 
 
 class CardListByColumn(generics.ListCreateAPIView):
@@ -89,3 +94,49 @@ class CardDetail(generics.RetrieveUpdateDestroyAPIView):
     def perform_update(self, serializer):
         if serializer.validated_data['column'].board.owner != self.request.user:
             raise PermissionDenied
+        serializer.save()
+
+
+class ReorderColumnCards(APIView):
+
+    def get_object(self, pk):
+        try:
+            column = Column.objects.get(pk=pk)
+        except Column.DoesNotExist:
+            raise Http404
+
+        if column.board.owner != self.request.user:
+            raise PermissionDenied
+
+        return column
+
+    def get(self, request, pk):
+        column = self.get_object(pk)
+        cards = column.cards.all()
+
+        order_dict = {}
+        for card in cards:
+            order_dict[card.pk] = card.order
+
+        return Response(order_dict)
+
+    def put(self, request, pk):
+        column = self.get_object(pk)
+        cards = column.cards.all()
+
+        serializer = ReorderColumnCardsSerializer(data=request.data)
+
+        updated = {}
+        if serializer.is_valid():
+            ordered_dict = serializer.validated_data['ordered_dict']
+
+            for card in cards:
+                if str(card.pk) in ordered_dict.keys():
+                    card.order = ordered_dict[str(card.pk)]
+                    card.save()
+                    print('{} now has order {}'.format(card.pk, ordered_dict[str(card.pk)]))
+                    updated[str(card.pk)] = ordered_dict[str(card.pk)]
+
+            return Response(updated)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
#7 

Сохранение очереди. Текущее решение крайне некрасивое, по человечески нужно было сделать так:

1) При сохранении по умолчанию ставить вес карточки равным идентификатору, тогда новая карточка всегда будет оказываться внизу списка.

2) При drag-and-drop смотреть, какие две карточки поменяли позиции и менять их веса местами.

К сожалению, понимание этого пришло сейчас, таску сдаю сейчас как есть. Проблема текущего (рабочего) решения с ORM в том, что если будет 999 карточек в коллекции, будет 999 запросов на изменение веса карточки. 
